### PR TITLE
Remove manage questions and make edit/manage more obvious

### DIFF
--- a/src/app/dashboard/edit-quest-dialog/edit-quest-dialog.component.html
+++ b/src/app/dashboard/edit-quest-dialog/edit-quest-dialog.component.html
@@ -18,9 +18,9 @@
         </mat-form-field>
     </form>
 
-    <div class="add-question">
+    <div class="modify-question">
         <button mat-stroked-button type="button" (click)="onAddQuestion()">
-            <mat-icon fontIcon="add"></mat-icon> Add Questions
+            <mat-icon fontIcon="edit"></mat-icon> Manage Questions
         </button>
     </div>
 

--- a/src/app/dashboard/edit-quest-dialog/edit-quest-dialog.component.scss
+++ b/src/app/dashboard/edit-quest-dialog/edit-quest-dialog.component.scss
@@ -10,6 +10,7 @@
     width: 100%;
 }
 
-.add-question {
+.modify-question {
+    padding-top: 1rem;
     width: 100%;
 }

--- a/src/app/preview-quest/preview-quest.component.html
+++ b/src/app/preview-quest/preview-quest.component.html
@@ -4,9 +4,10 @@
       <mat-card-title>{{ quest?.questName }}</mat-card-title>
       <mat-card-subtitle>{{ quest?.questDescription }}</mat-card-subtitle>
       <span class="spacer"></span>
-      <button mat-icon-button (click)="openEditQuestDialog(quest)">
+      <button mat-stroked-button (click)="openEditQuestDialog(quest)">
         <mat-icon>edit</mat-icon>
-      </button>
+        Edit Quest / Questions
+      </button>      
     </mat-card-header>
     <mat-card-content>
       <mat-chip color="primary" selected>{{ quest?.questSubject }}</mat-chip>
@@ -15,7 +16,7 @@
   <button mat-raised-button color="primary" (click)="startQuest()" [disabled]="quest?.questions?.length === 0">
     Start the Quest
   </button>
-  <mat-tab-group (selectedTabChange)="onTabChange($event)">
+  <mat-tab-group>
     <mat-tab label="Preview Questions">
       <ng-container *ngIf="quest; else loading">
         <!-- Check if there are questions associated with the quest -->
@@ -28,21 +29,6 @@
                           [questions]="quest?.questions || []" 
                           [questionsEditable]="true" 
                           [hideAnswers]="true"></app-questions>
-        </ng-template>
-      </ng-container>
-    </mat-tab>
-    <mat-tab label="Manage Questions">
-      <ng-container *ngIf="quest; else loading">
-        <div *ngIf="quest?.questions?.length === 0; else manageQuestions">
-          <p>No questions have been assigned to this quest.</p>
-        </div>
-
-        <ng-template #manageQuestions>
-          <app-questions 
-            [quest]="quest"    
-            [questions]="quest?.questions || []" 
-            [questionsEditable]="false">
-          </app-questions>
         </ng-template>
       </ng-container>
     </mat-tab>

--- a/src/app/preview-quest/preview-quest.component.ts
+++ b/src/app/preview-quest/preview-quest.component.ts
@@ -70,9 +70,6 @@ export class PreviewQuestComponent implements OnInit {
     });
   }
 
-  onTabChange($event: MatTabChangeEvent) {
-    // Handle tab changes if needed
-  }
 
   startQuest() {
     this.router.navigate(['/quest/start/', this.quest?.id], {


### PR DESCRIPTION
Removes the tab for manage questions when previewing a quest and makes the buttons for editing/managing a quest/question more obvious on that page